### PR TITLE
Add additional storage to integration test environment

### DIFF
--- a/test/test.tf
+++ b/test/test.tf
@@ -58,6 +58,9 @@ module "aws_deploy-test-gw" {
   instance_type     = "t3.large"
   ami_name          = "aeternity-ubuntu-16.04-*"
 
+  additional_storage      = 1
+  additional_storage_size = 5
+
   aeternity = {
     package = "${var.package}"
   }


### PR DESCRIPTION
As additional storage configuration has been introduced to `test` environment [node configuration](https://github.com/aeternity/infrastructure/blob/master/ansible/vars/aeternity/test.yml#L8-L9) it's now required in all integration tests that use that configuration during bootstrap.
