### PR TITLE
Forward Load balancer sticky session cookies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,8 @@ resource "aws_cloudfront_distribution" "cf" {
       query_string = true
 
       cookies {
-        forward = "none"
+        forward           = "whitelist"
+        whitelisted_names = ["AWSALB"]
       }
     }
 


### PR DESCRIPTION
Cloudfront blocks all cookies, but the Load balancer needs to set a cookie to manage sticky sessions

in scope of https://www.pivotaltracker.com/story/show/164978300

docs: 
CF: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html
ELB: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#sticky-sessions
