### PR TITLE
Remove certificate validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,24 +4,6 @@ resource "aws_acm_certificate" "cert" {
   subject_alternative_names = ["${var.api_alias}"]
 }
 
-resource "aws_route53_record" "cert_validation" {
-  count   = "${var.validate_cert ? 1: 0}"
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${var.dns_zone}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
-  ttl     = 60
-}
-
-resource "aws_acm_certificate_validation" "cert" {
-  count           = "${var.validate_cert ? 1: 0}"
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-
-  validation_record_fqdns = [
-    "${aws_route53_record.cert_validation.fqdn}",
-  ]
-}
-
 resource "aws_route53_record" "main-api" {
   zone_id = "${var.dns_zone}"
   name    = "${var.api_dns}"
@@ -79,7 +61,7 @@ resource "aws_cloudfront_distribution" "cf" {
   aliases = ["${var.api_dns}", "${var.api_alias}"]
 
   viewer_certificate {
-    acm_certificate_arn = "${var.validate_cert ? aws_acm_certificate_validation.cert.certificate_arn : aws_acm_certificate.cert.arn}"
+    acm_certificate_arn = "${aws_acm_certificate.cert.arn}"
 
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.1_2016"

--- a/test/test.tf
+++ b/test/test.tf
@@ -84,6 +84,4 @@ module "aws_test_gateway" {
 
   api_dns   = "${substr(var.env_domain, 0, 15)}${var.domain_sfx}"
   api_alias = "${substr(var.env_domain, 0, 15)}${var.domain_sfx}"
-
-  validate_cert = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,3 @@ variable "loadbalancers_regions" {
 
 variable "api_dns" {}
 variable "api_alias" {}
-
-variable "validate_cert" {
-  default = false
-}


### PR DESCRIPTION
Because of terraform 0.11 limitation, certificate validation can not be toggled with a variable. Resource is required even if not really used when defined in a ternary check.
More specifically `"${var.validate_cert ? aws_acm_certificate_validation.cert.certificate_arn : aws_acm_certificate.cert.arn}"`
both `aws_acm_certificate_validation.cert.certificate_arn` and `aws_acm_certificate.cert.arn` are checked for existence prior evaluating the result.
In this case if we have `false` for `validate_cert`, terraform will validate  `aws_acm_certificate_validation.cert.certificate_arn` which in this case will have `count = 0` and will not be created. As result it will throw an error (although it should not be used) :
```
 Resource 'aws_acm_certificate_validation.cert' not found for variable 'aws_acm_certificate_validation.cert.certificate_arn'
```
More: https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements#conditionally-omitted-argumentshttps://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements#conditionally-omitted-arguments