### PR TITLE
Refactor certificate validation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # terraform-aws-api-gateway
 
 ## Usage: 
-A certificate resource (`cert`) with a certificate needs to be created in the root module and pass the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) as `certificate_arn`
+A certificate resource (e.g. `cert`) needs to be created in the root module then the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) passed as `certificate_arn` (string):
 
 * For automatic validation: use `aws_acm_certificate_validation` and pass `aws_acm_certificate_validation.cert.certificate_arn.cert.certificate_arn` 
 (see [test.tf](./test/test.tf))
 
-* For manual validation: create simple `aws_acm_certificate` and pass `aws_acm_certificate.cert.arn` (apply may fail until validation is complete)
+* For manual validation: create simple `aws_acm_certificate` and pass `aws_acm_certificate.cert.arn` (`terraform apply` may fail until domain validation is complete)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # terraform-aws-api-gateway
+
+## Usage: 
+A certificate resource (`cert`) with a certificate needs to be created in the root module and pass the ARN as `certificate_arn`
+
+* For automatic validation: use `aws_acm_certificate_validation` and pass `aws_acm_certificate_validation.cert.certificate_arn.cert.certificate_arn` 
+(see [test.tf](./test/test.tf))
+
+* For manual validation: create simple `aws_acm_certificate` and pass `aws_acm_certificate.cert.arn` (apply may fail until validation is complete)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terraform-aws-api-gateway
 
 ## Usage: 
-A certificate resource (`cert`) with a certificate needs to be created in the root module and pass the ARN as `certificate_arn`
+A certificate resource (`cert`) with a certificate needs to be created in the root module and pass the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) as `certificate_arn`
 
 * For automatic validation: use `aws_acm_certificate_validation` and pass `aws_acm_certificate_validation.cert.certificate_arn.cert.certificate_arn` 
 (see [test.tf](./test/test.tf))

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,3 @@
-resource "aws_acm_certificate" "cert" {
-  domain_name               = "${var.api_dns}"
-  validation_method         = "DNS"
-  subject_alternative_names = ["${var.api_alias}"]
-}
-
-resource "aws_route53_record" "cert_validation" {
-  count   = "${var.validate_cert ? 1: 0}"
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${var.dns_zone}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
-  ttl     = 60
-}
-
-resource "aws_acm_certificate_validation" "cert" {
-  count           = "${var.validate_cert ? 1: 0}"
-  certificate_arn = "${aws_acm_certificate.cert.arn}"
-
-  validation_record_fqdns = [
-    "${aws_route53_record.cert_validation.fqdn}",
-  ]
-}
-
 resource "aws_route53_record" "main-api" {
   zone_id = "${var.dns_zone}"
   name    = "${var.api_dns}"
@@ -79,7 +55,7 @@ resource "aws_cloudfront_distribution" "cf" {
   aliases = ["${var.api_dns}", "${var.api_alias}"]
 
   viewer_certificate {
-    acm_certificate_arn = "${var.validate_cert ? aws_acm_certificate_validation.cert.certificate_arn : aws_acm_certificate.cert.arn}"
+    acm_certificate_arn = "${var.certificate_arn}"
 
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.1_2016"
@@ -103,7 +79,7 @@ resource "aws_route53_record" "origin-api" {
   name    = "origin-${var.api_dns}"
   type    = "A"
 
-  health_check_id = "${element( aws_route53_health_check.health.*.id, count.index)}"
+  health_check_id = "${element(aws_route53_health_check.health.*.id, count.index)}"
   set_identifier  = "${element(var.loadbalancers_regions, count.index)}"
 
   alias {

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,4 @@ variable "loadbalancers_regions" {
 variable "api_dns" {}
 variable "api_alias" {}
 
-variable "validate_cert" {
-  default = false
-}
+variable "certificate_arn" {}


### PR DESCRIPTION
For integration tests the certificate is autovalidated, while in RL environments it is currently validated manually.

Because of terraform 0.11 limitation, certificate validation can not be toggled with a variable. Resource is checked for existence even if not really used when defined in a ternary check.
More specifically `"${var.validate_cert ? aws_acm_certificate_validation.cert.certificate_arn : aws_acm_certificate.cert.arn}"`
both `aws_acm_certificate_validation.cert.certificate_arn` and `aws_acm_certificate.cert.arn` are checked for existence prior evaluating the result.
In this case if we have `false` for `validate_cert`, terraform will validate  `aws_acm_certificate_validation.cert.certificate_arn` which in this case will have `count = 0` and will not be created. As a result the resource is missing in the ternary operator and it will throw an error :
```
 Resource 'aws_acm_certificate_validation.cert' not found for variable 'aws_acm_certificate_validation.cert.certificate_arn'
```
More: https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements#conditionally-omitted-argumentshttps://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements#conditionally-omitted-arguments

In this refactoring module now requires `certificate_arn` variable which is the ARN of a certificate resource (either `acm_certificate`, or `acm_certificate_validation`). This cert resource should be built in the root module depending on the way certificate is validated. 