### PR TITLE
Fix CDN distribution cache configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ resource "aws_cloudfront_distribution" "api_gate" {
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = "api_lb"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 31536000
   }
 
   restrictions {


### PR DESCRIPTION
I seem that if custom cache configuration is disabled, cloud front would cache all responses by default if they lack cache-control headers. I was expecting the opposite.

With this configuration it should not cache response that are missing cache-control headers (default_ttl = 0) and it allow the backend/origin to set cache ttl in the range of 0 - 1 year.