### PR TITLE
Disable ALB cookie forwarding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,7 @@ resource "aws_cloudfront_distribution" "api_gate" {
       headers      = var.headers
 
       cookies {
-        forward           = "whitelist"
-        whitelisted_names = ["AWSALB"]
+        forward = "none"
       }
     }
 


### PR DESCRIPTION
It harms the CDN edge caches and it's not useful anyway