### PR TITLE
Forward all headers to api_ae_mdw

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,7 @@ resource "aws_cloudfront_distribution" "api_gate" {
 
     forwarded_values {
       query_string = true
+      headers      = "*"
 
       cookies {
         forward = "none"


### PR DESCRIPTION
By default headers are not forwarded and we need them in `mdw` (not applied)